### PR TITLE
Add support for inclusions to override exclusions

### DIFF
--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -259,7 +259,7 @@ def create_new_backup(user_data_location: str,
 
     if exclude_file and not os.path.isfile(exclude_file):
         raise CommandLineError(f"Exclude file not found: {exclude_file}")
-    
+
     if include_file and not os.path.isfile(include_file):
         raise CommandLineError(f"Include file not found: {include_file}")
 
@@ -473,7 +473,7 @@ which version of the file to recover by choosing from dates
 where the backup has a new copy the file due to the file being
 modified. This option requires the -b option to specify which
 backup location to search.""")
-    
+
     user_input.add_argument("--force-copy", action="store_true", help="""
 Copy all files instead of linking to files previous backups. The
 new backup will contain new copies of all of the user's files,


### PR DESCRIPTION
Let's say that a user has a certain directory they want to exclude from backups called `Mostly Exclude/` that looks like this:
```
User Home Directory/Misc/Mostly Exclude/
   Unwanted directory 1/
   ...
   Unwanted directory 200/
   Wanted directory/
   unwanted file 1.dll
   ...
   unwanted file 3000.txt
   wanted file.jpg
```
If the user backups their `User Home Directory`, they can create an exclude file called `exclude.txt` that looks like this:
```
Misc/Mostly Exclude
```
and run vintage backup like this:
```
python vintagebackup.py -u "User Home Directory" -e "exclude.txt"
```
to exclude the entire directory.

With this change, a user can now backup the wanted files within a mostly excluded directory. They can create a file called `include.txt` containing
```
Wanted Directory
wanted file
```
and call Vintage Backup like so
```
python vintagebackup.py -u "User Home Directory" -e "exclude.txt" -i "include.txt"
```
The wanted files and directories will be backed up while excluding everything else.