### PR TITLE
Move backups to a new location

### DIFF
--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1241,9 +1241,8 @@ Move all backups made on or after the specified date (YYYY-MM-DD)."""))
         print_backup_storage_stats(args.backup_folder)
         exit_code = 0
     except CommandLineError as error:
-        logger.error(error)
-        logger.info("")
         user_input.print_usage()
+        logger.error(error)
     except Exception:
         if action:
             logger.error(f"An error prevented the {action} from completing.")


### PR DESCRIPTION
Move a set of the most recent backups to a new location or backup medium. The backups at the original location are not affected.

Required arguments:
- `--backup-folder <folder>`: The current location of the backups.
- `--move-backup <folder>`: The new destination of the backups.
- One of `--move-count <number>`, `--move-age <time span>`, `--move-since <YYYY-MM-DD>` to specify which of the most recent backups to move.

Closes #15