### PR TITLE
Restore backup

### DIFF
--- a/test.py
+++ b/test.py
@@ -993,7 +993,7 @@ class RestorationTest(unittest.TestCase):
             exit_code = vintagebackup.main(["--restore",
                                             "--user-folder", user_folder,
                                             "--backup-folder", backup_folder,
-                                            "--last-backup", "--delete-new"])
+                                            "--last-backup", "--delete-extra"])
 
             self.assertEqual(exit_code, 0)
             last_backup = vintagebackup.find_previous_backup(backup_path)
@@ -1036,7 +1036,7 @@ class RestorationTest(unittest.TestCase):
             exit_code = vintagebackup.main(["--restore",
                                             "--user-folder", user_folder,
                                             "--backup-folder", backup_folder,
-                                            "--last-backup", "--keep-new"])
+                                            "--last-backup", "--keep-extra"])
 
             self.assertEqual(exit_code, 0)
             last_backup = vintagebackup.find_previous_backup(backup_path)
@@ -1081,7 +1081,7 @@ class RestorationTest(unittest.TestCase):
             exit_code = vintagebackup.main(["--restore",
                                             "--user-folder", user_folder,
                                             "--backup-folder", backup_folder,
-                                            "--choose-backup", "--delete-new",
+                                            "--choose-backup", "--delete-extra",
                                             "--choice", str(choice)])
 
             self.assertEqual(exit_code, 0)
@@ -1126,7 +1126,7 @@ class RestorationTest(unittest.TestCase):
             exit_code = vintagebackup.main(["--restore",
                                             "--user-folder", user_folder,
                                             "--backup-folder", backup_folder,
-                                            "--choose-backup", "--keep-new",
+                                            "--choose-backup", "--keep-extra",
                                             "--choice", str(choice)])
 
             self.assertEqual(exit_code, 0)


### PR DESCRIPTION
This new function overwrites the files in the user's folder with the files in a chosen backup (`--last-backup` to use the most recent, `--choose-backup` to pick from a terminal menu). Unlike `--recover`, which copies individual files/folders and renames the recovered data to avoid clobbering user data, `--restore` overwrites all files with those in the backup. If there are files that are not present in the last backup, `--keep-extra` preserves them and `--delete-extra` deletes them. Note that `--delete-extra` not only deletes files that are newly created since the last backup, but also any files that were filtered out with `--filter`.

Closes #54.