### PR TITLE
New option: --hard-link-count

### DIFF
--- a/test.py
+++ b/test.py
@@ -166,7 +166,6 @@ def run_backup(run_method: Invocation,
                filter_file: Path | None,
                examine_whole_file: bool,
                force_copy: bool,
-               randomly_copy_probability: float,
                timestamp: datetime.datetime) -> int:
     """Create a new backup while choosing a direct function call or a CLI invocation."""
     if run_method == Invocation.function:
@@ -175,7 +174,7 @@ def run_backup(run_method: Invocation,
                                         filter_file=filter_file,
                                         examine_whole_file=examine_whole_file,
                                         force_copy=force_copy,
-                                        randomly_copy_probability=randomly_copy_probability,
+                                        max_average_hard_links=None,
                                         timestamp=timestamp)
         return 0
     elif run_method == Invocation.cli:
@@ -211,7 +210,6 @@ class BackupTest(unittest.TestCase):
                                        filter_file=None,
                                        examine_whole_file=False,
                                        force_copy=False,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
                 first_backups = vintagebackup.last_n_backups(backup_location, "all")
@@ -227,7 +225,6 @@ class BackupTest(unittest.TestCase):
                                        filter_file=None,
                                        examine_whole_file=False,
                                        force_copy=False,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
                 second_backups = vintagebackup.last_n_backups(backup_location, "all")
@@ -243,7 +240,6 @@ class BackupTest(unittest.TestCase):
                                        filter_file=None,
                                        examine_whole_file=False,
                                        force_copy=True,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
                 third_backups = vintagebackup.last_n_backups(backup_location, "all")
@@ -260,7 +256,6 @@ class BackupTest(unittest.TestCase):
                                        filter_file=None,
                                        examine_whole_file=True,
                                        force_copy=False,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
                 fourth_backups = vintagebackup.last_n_backups(backup_location, "all")
@@ -278,7 +273,6 @@ class BackupTest(unittest.TestCase):
                                        filter_file=None,
                                        examine_whole_file=True,
                                        force_copy=True,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
                 fifth_backups = vintagebackup.last_n_backups(backup_location, "all")
@@ -303,7 +297,7 @@ class BackupTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             changed_file_name = user_data/"sub_directory_2"/"sub_sub_directory_0"/"file_1.txt"
@@ -315,7 +309,7 @@ class BackupTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             backup_1, backup_2 = vintagebackup.last_n_backups(backup_location, "all")
             contents_1 = directory_contents(backup_1)
@@ -347,7 +341,7 @@ class BackupTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             last_backup = vintagebackup.find_previous_backup(backup_path)
             assert last_backup is not None
@@ -387,7 +381,6 @@ class FilterTest(unittest.TestCase):
                                        filter_file=Path(filter_file.name),
                                        examine_whole_file=False,
                                        force_copy=False,
-                                       randomly_copy_probability=0.0,
                                        timestamp=unique_timestamp())
                 self.assertEqual(exit_code, 0)
 
@@ -430,7 +423,7 @@ class FilterTest(unittest.TestCase):
                                             filter_file=Path(filter_file.name),
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             self.assertEqual(len(vintagebackup.last_n_backups(backup_location, "all")), 1)
@@ -497,7 +490,7 @@ class RecoveryTest(unittest.TestCase):
                                                 filter_file=None,
                                                 examine_whole_file=False,
                                                 force_copy=False,
-                                                randomly_copy_probability=0.0,
+                                                max_average_hard_links=None,
                                                 timestamp=unique_timestamp())
                 file = (user_data/"sub_directory_0"/"sub_sub_directory_0"/"file_0.txt").resolve()
                 moved_file_path = file.parent/(file.name + "_moved")
@@ -518,7 +511,7 @@ class RecoveryTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             file_path = (user_data/"sub_directory_0"/"sub_sub_directory_0"/"file_0.txt").resolve()
             vintagebackup.recover_path(file_path, backup_location, 0)
@@ -537,7 +530,7 @@ class RecoveryTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             folder_path = (user_data/"sub_directory_1").resolve()
             vintagebackup.recover_path(folder_path, backup_location, 0)
@@ -557,7 +550,7 @@ class RecoveryTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             folder_path = (user_data/"sub_directory_1"/"sub_sub_directory_1").resolve()
             chosen_file = vintagebackup.search_backups(folder_path, backup_location, 1)
@@ -606,7 +599,7 @@ class DeleteBackupTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             backup_count_before = len(vintagebackup.last_n_backups(backup_location, "all"))
@@ -630,7 +623,7 @@ class DeleteBackupTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             backup_count_before = len(vintagebackup.last_n_backups(backup_location, "all"))
@@ -796,7 +789,7 @@ class MoveBackupsTest(unittest.TestCase):
                                                 filter_file=None,
                                                 examine_whole_file=False,
                                                 force_copy=False,
-                                                randomly_copy_probability=0.0,
+                                                max_average_hard_links=None,
                                                 timestamp=unique_timestamp())
 
             for method in Invocation:
@@ -835,7 +828,7 @@ class MoveBackupsTest(unittest.TestCase):
                                                 filter_file=None,
                                                 examine_whole_file=False,
                                                 force_copy=False,
-                                                randomly_copy_probability=0.0,
+                                                max_average_hard_links=None,
                                                 timestamp=unique_timestamp())
 
             move_count = 5
@@ -896,7 +889,7 @@ class VerificationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             mismatch_file = Path("sub_directory_1")/"sub_sub_directory_2"/"file_0.txt"
@@ -1095,7 +1088,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 1)
@@ -1109,7 +1102,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 2)
 
@@ -1142,7 +1135,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 1)
@@ -1156,7 +1149,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 2)
 
@@ -1190,7 +1183,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 1)
@@ -1204,7 +1197,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 2)
 
@@ -1239,7 +1232,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 1)
@@ -1253,7 +1246,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
             self.assertEqual(len(vintagebackup.all_backups(backup_path)), 2)
 
@@ -1291,7 +1284,7 @@ class RestorationTest(unittest.TestCase):
                                             filter_file=None,
                                             examine_whole_file=False,
                                             force_copy=False,
-                                            randomly_copy_probability=0.0,
+                                            max_average_hard_links=None,
                                             timestamp=unique_timestamp())
 
             exit_code = vintagebackup.main(["--restore",


### PR DESCRIPTION
In order to limit the time a backup takes on Windows systems, randomly copy files instead of hard-linking them when they haven't changed. The probability of copying is specified by the new command line option --hard-link-count, which is interpreted as the average number of times a file is hard linked to previous backups before another copy is made. The files are chosen randomly because counting hard links when there are a lot of links takes a long time [1], which is the problem we're trying to fix.

Implements and closes #67

[1] See all the sources in issues #16 and #26.