### PR TITLE
Preview filter and shorter directory listing format

### DIFF
--- a/testing/test.py
+++ b/testing/test.py
@@ -1292,7 +1292,7 @@ def read_verify_file(verify_file: io.TextIOBase) -> set[Path]:
         if os.sep in line:
             current_directory = Path(line.removesuffix("\n"))
         else:
-            files_from_verify.add(current_directory/line.removesuffix("\n"))
+            files_from_verify.add(current_directory/line.removeprefix("    ").removesuffix("\n"))
     return files_from_verify
 
 

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1797,6 +1797,33 @@ def delete_before_backup(args: argparse.Namespace) -> None:
     start_backup(args)
 
 
+def tree_listing(
+        listing: Iterable[tuple[Path, list[str]]],
+        output: io.TextIOBase | None = None) -> None:
+    """
+    Print an indented listing of paths to show a simple tree structure.
+
+    :param listing: The list of paths. Each entry should be a directory path and the files it
+    contains. The first directory should be the root directory that contains all other paths.
+    :param output: An alternate destination for the printed output.
+    """
+    root: Path | None = None
+    for directory, file_names in listing:
+        if not root:
+            root = directory
+
+        single_indent = "  "
+        depth = len(directory.relative_to(root).parts)
+        indent = single_indent*depth
+        if depth == 0:
+            print(f"{absolute_path(root)}{os.sep}", file=output)
+        else:
+            print(f"{indent}{directory.name}{os.sep}", file=output)
+
+        for file_name in file_names:
+            print(f"{indent}{single_indent}{file_name}", file=output)
+
+
 def argument_parser() -> argparse.ArgumentParser:
     """Create the parser for command line arguments."""
     user_input = argparse.ArgumentParser(

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1813,6 +1813,18 @@ def path_listing(
             print(f"    {file_name}", file=output)
 
 
+def preview_filter(args: argparse.Namespace) -> None:
+    """Print a list of files that will make it through the --filter file."""
+    user_folder = get_existing_path(args.user_folder, "user folder")
+    filter_file = path_or_none(args.filter)
+    output_file = path_or_none(args.preview_filter)
+    if output_file:
+        with open(output_file, "w", encoding="utf8") as output:
+            path_listing(Backup_Set(user_folder, filter_file), output)
+    else:
+        path_listing(Backup_Set(user_folder, filter_file), None)
+
+
 def argument_parser() -> argparse.ArgumentParser:
     """Create the parser for command line arguments."""
     user_input = argparse.ArgumentParser(
@@ -1901,6 +1913,16 @@ comparison will be placed in the folder RESULT_DIR. The result is three files: a
 match, a list of files that do not match, and a list of files that caused errors during the
 comparison. The --backup-folder argument is required. If a filter file was used
 to create the backup, then --filter should be supplied as well."""))
+
+    only_one_action_group.add_argument(
+        "--preview-filter",
+        metavar="FILE_NAME",
+        nargs="?",
+        const=False,
+        help=format_help(
+"""Create a list of the files and folders that will be backed up after being filtered by the
+--filter file argument. The argument is a file name where the list will be written. If there is no
+argument, the list will be written to the console. The --user-folder argument is required."""))
 
     only_one_action_group.add_argument("--restore", action="store_true", help=format_help(
 """This action restores the user's folder to a previous, backed up state. Any existing user files
@@ -2226,6 +2248,7 @@ def main(argv: list[str]) -> int:
             else choose_purge_target_from_backups if args.purge_list
             else delete_old_backups if args.delete_only
             else delete_before_backup if toggle_is_set(args, "delete_first")
+            else preview_filter if args.preview_filter is not None
             else start_backup)
         action(args)
         return 0

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1828,6 +1828,22 @@ def tree_listing(
             print(f"{indent}{single_indent}{file_name}", file=output)
 
 
+def short_listing(
+        listing: Iterable[tuple[Path, list[str]]],
+        output: io.TextIOBase | None = None) -> None:
+    """
+    Print a list of paths with file names listed under their directories.
+
+    :param listing: The list of paths. Each entry should be a directory path and the files it
+    contains. The first directory should be the root directory that contains all other paths.
+    :param output: An alternate destination for the printed output.
+    """
+    for directory, file_names in listing:
+        print(f"{absolute_path(directory)}{os.sep}", file=output)
+        for file_name in file_names:
+            print(f"    {file_name}", file=output)
+
+
 def argument_parser() -> argparse.ArgumentParser:
     """Create the parser for command line arguments."""
     user_input = argparse.ArgumentParser(

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1812,17 +1812,17 @@ def tree_listing(
     :param output: An alternate destination for the printed output.
     """
     root: Path | None = None
+    single_indent = "  "
     for directory, file_names in listing:
         if not root:
             root = directory
+            to_print = absolute_path(root)
+        else:
+            to_print = directory.name
 
-        single_indent = "  "
         depth = len(directory.relative_to(root).parts)
         indent = single_indent*depth
-        if depth == 0:
-            print(f"{absolute_path(root)}{os.sep}", file=output)
-        else:
-            print(f"{indent}{directory.name}{os.sep}", file=output)
+        print(f"{indent}{to_print}{os.sep}", file=output)
 
         for file_name in file_names:
             print(f"{indent}{single_indent}{file_name}", file=output)

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1121,8 +1121,8 @@ def verify_last_backup(result_folder: Path, backup_folder: Path, filter_file: Pa
 
         def write_directory(output: io.TextIOBase, directory: Path, file_names: list[str]) -> None:
             if file_names:
-                output.write(f"{directory}\n")
-                output.writelines(f"{name}\n" for name in file_names)
+                output.write(f"{absolute_path(directory)}{os.sep}\n")
+                output.writelines(f"    {name}\n" for name in file_names)
 
         for directory, file_names in Backup_Set(user_folder, filter_file):
             relative_directory = directory.relative_to(user_folder)

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1813,6 +1813,7 @@ def tree_listing(
     """
     root: Path | None = None
     single_indent = "  "
+    to_print: Path | str
     for directory, file_names in listing:
         if not root:
             root = directory

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1797,39 +1797,7 @@ def delete_before_backup(args: argparse.Namespace) -> None:
     start_backup(args)
 
 
-def tree_listing(
-        listing: Iterable[tuple[Path, list[str]]],
-        output: io.TextIOBase | None = None) -> None:
-    """
-    Print an indented listing of paths to show a simple tree structure.
-
-    The first line of the output will be the base directory whose absolute path will be printed in
-    full. The rest of the lines will be printed relative to this base directory and indented to show
-    how paths are nested.
-
-    :param listing: The list of paths. Each entry should be a directory path and the files it
-    contains. The first directory should be the root directory that contains all other paths.
-    :param output: An alternate destination for the printed output.
-    """
-    root: Path | None = None
-    single_indent = "  "
-    to_print: Path | str
-    for directory, file_names in listing:
-        if not root:
-            root = directory
-            to_print = absolute_path(root)
-        else:
-            to_print = directory.name
-
-        depth = len(directory.relative_to(root).parts)
-        indent = single_indent*depth
-        print(f"{indent}{to_print}{os.sep}", file=output)
-
-        for file_name in file_names:
-            print(f"{indent}{single_indent}{file_name}", file=output)
-
-
-def short_listing(
+def path_listing(
         listing: Iterable[tuple[Path, list[str]]],
         output: io.TextIOBase | None = None) -> None:
     """
@@ -1843,22 +1811,6 @@ def short_listing(
         print(f"{absolute_path(directory)}{os.sep}", file=output)
         for file_name in file_names:
             print(f"    {file_name}", file=output)
-
-
-def listing(
-        listing: Iterable[tuple[Path, list[str]]],
-        output: io.TextIOBase | None = None) -> None:
-    """
-    Print a list of file paths.
-
-    :param listing: The list of paths. Each entry should be a directory path and the files it
-    contains.
-    :param output: An alternate destination for the printed output.
-    """
-    for directory, file_names in listing:
-        abs_directory = absolute_path(directory)
-        for file_name in file_names:
-            print(f"{abs_directory/file_name}", file=output)
 
 
 def argument_parser() -> argparse.ArgumentParser:

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1803,6 +1803,10 @@ def tree_listing(
     """
     Print an indented listing of paths to show a simple tree structure.
 
+    The first line of the output will be the base directory whose absolute path will be printed in
+    full. The rest of the lines will be printed relative to this base directory and indented to show
+    how paths are nested.
+
     :param listing: The list of paths. Each entry should be a directory path and the files it
     contains. The first directory should be the root directory that contains all other paths.
     :param output: An alternate destination for the printed output.

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1119,8 +1119,10 @@ def verify_last_backup(result_folder: Path, backup_folder: Path, filter_file: Pa
         for file in (matching_file, mismatching_file, error_file):
             file.write(f"Comparison: {user_folder} <---> {backup_folder}\n")
 
-        def file_name_line_writer(relative_directory: Path) -> Callable[[str], str]:
-            return lambda file_name: f"{relative_directory/file_name}\n"
+        def write_directory(output: io.TextIOBase, directory: Path, file_names: list[str]) -> None:
+            if file_names:
+                output.write(f"{directory}\n")
+                output.writelines(f"{name}\n" for name in file_names)
 
         for directory, file_names in Backup_Set(user_folder, filter_file):
             relative_directory = directory.relative_to(user_folder)
@@ -1131,10 +1133,9 @@ def verify_last_backup(result_folder: Path, backup_folder: Path, filter_file: Pa
                 file_names,
                 shallow=False)
 
-            stringifier = file_name_line_writer(relative_directory)
-            matching_file.writelines(map(stringifier, matches))
-            mismatching_file.writelines(map(stringifier, mismatches))
-            error_file.writelines(map(stringifier, errors))
+            write_directory(matching_file, directory, matches)
+            write_directory(mismatching_file, directory, mismatches)
+            write_directory(error_file, directory, errors)
 
 
 def restore_backup(

--- a/vintagebackup.py
+++ b/vintagebackup.py
@@ -1844,6 +1844,22 @@ def short_listing(
             print(f"    {file_name}", file=output)
 
 
+def listing(
+        listing: Iterable[tuple[Path, list[str]]],
+        output: io.TextIOBase | None = None) -> None:
+    """
+    Print a list of file paths.
+
+    :param listing: The list of paths. Each entry should be a directory path and the files it
+    contains.
+    :param output: An alternate destination for the printed output.
+    """
+    for directory, file_names in listing:
+        abs_directory = absolute_path(directory)
+        for file_name in file_names:
+            print(f"{abs_directory/file_name}", file=output)
+
+
 def argument_parser() -> argparse.ArgumentParser:
     """Create the parser for command line arguments."""
     user_input = argparse.ArgumentParser(


### PR DESCRIPTION
Two changes in this PR:

1. Add a `--preview-filter` function so users can see exactly which files will make it through a filter.
2. Print the above file list in a shorter, easier to read format. Apply this format to `--verify`, as well.

The short file list format is of the form:
```
/path/to/folder/
    file1.txt
    file2.txt
    ...
/path/to/folder/subfolder/
   file3.txt
   ...
```
and similarly for Windows paths. This format should be easier to read since the file names are not way to the right--often beyond the edge of the screen for deeply nested files.