### PR TITLE
Do not delete more than --max-deletions backups

### DIFF
--- a/lib/backup_deletion.py
+++ b/lib/backup_deletion.py
@@ -273,6 +273,9 @@ def delete_old_backups(args: argparse.Namespace) -> None:
     Arguments:
         args: Parsed command line
 
+    Note: The argument `args.max_deletions` is reduced by the number of deletions to make sure that
+        option is respected if multiple rounds of backup deletions are required.
+
     Raises:
         CommandLineError: If --delete-only is used and there are no backups at --backup-folder.
     """
@@ -295,3 +298,9 @@ def delete_old_backups(args: argparse.Namespace) -> None:
             backup_folder, args.free_up, verify_checksum_result_folder, min_backups_remaining)
         delete_backups_older_than(
             backup_folder, args.delete_after, verify_checksum_result_folder, min_backups_remaining)
+
+        if args.max_deletions:
+            backup_count_after = len(util.all_backups(backup_folder))
+            backups_deleted = backup_count - backup_count_after
+            deletions_remaining = int(args.max_deletions) - backups_deleted
+            args.max_deletions = str(max(deletions_remaining, 0))

--- a/testing/test.py
+++ b/testing/test.py
@@ -2339,9 +2339,9 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
     def test_keep_x_after_respects_maximum_deletions(self) -> None:
         """Make sure all --keep-x-after options respect --max-deletions."""
         max_deletions = 50
+        starting_backup_count = 100
         for option in ("weekly", "monthly", "yearly"):
-            create_old_daily_backups(self.backup_path, 100)
-            starting_backup_count = len(util.all_backups(self.backup_path))
+            create_old_daily_backups(self.backup_path, starting_backup_count)
             main_assert_no_error_log([
                 "--backup-folder", str(self.backup_path),
                 f"--keep-{option}-after", "1d",
@@ -2349,7 +2349,28 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
                 "--max-deletions", str(max_deletions)],
                 self)
             retained_backup_count = len(util.all_backups(self.backup_path))
-            self.assertEqual(starting_backup_count - retained_backup_count, 50)
+            actual_deletions = starting_backup_count - retained_backup_count
+            self.assertEqual(actual_deletions, max_deletions)
+            self.reset_backup_folder()
+
+    def test_keep_x_after_with_backup_respects_maximum_deletions(self) -> None:
+        """Make sure all --keep-x-after options respect --max-deletions."""
+        create_user_data(self.user_path)
+        max_deletions = 50
+        for option in ("weekly", "monthly", "yearly"):
+            starting_backup_count = 100
+            create_old_daily_backups(self.backup_path, starting_backup_count)
+            starting_backup_count = len(util.all_backups(self.backup_path))
+            main_assert_no_error_log([
+                "--user-folder", str(self.user_path),
+                "--backup-folder", str(self.backup_path),
+                f"--keep-{option}-after", "1d",
+                "--max-deletions", str(max_deletions)],
+                self)
+            starting_backup_count += 1  # for the new backup created above
+            retained_backup_count = len(util.all_backups(self.backup_path))
+            actual_deletions = starting_backup_count - retained_backup_count
+            self.assertEqual(actual_deletions, max_deletions)
             self.reset_backup_folder()
 
     @unittest.skipUnless(platform.system() == "Windows", "OSError.winerror only valid on Windows.")


### PR DESCRIPTION
Make sure that, if delete_old_backups() is called more than once, the total number of backups deleted is never more than specified with --max-deletions.

Add tests to confirm correct behavior.

Fixes #252