### PR TITLE
Make --keep-monthly-after act more reasonably

### DIFF
--- a/lib/backup_deletion.py
+++ b/lib/backup_deletion.py
@@ -93,7 +93,7 @@ def delete_backups_older_than(
     if not last_backup:
         return
     now = util.backup_datetime(last_backup)
-    timestamp_to_keep = dates.parse_time_span_to_timepoint(time_span, now)
+    timestamp_to_keep = dates.past_timepoint(time_span, now)
     first_deletion_message = (
         f"Deleting backups prior to {timestamp_to_keep.strftime('%Y-%m-%d %H:%M:%S')}.")
 
@@ -215,7 +215,7 @@ def delete_too_frequent_backups(
         if time_span_str is None:
             continue
 
-        date_cutoff = dates.parse_time_span_to_timepoint(time_span_str, now)
+        date_cutoff = dates.past_timepoint(time_span_str, now)
         backups = list(filter(old_enough(date_cutoff), util.all_backups(backup_folder)))
         while len(backups) > 1 and deletion_count < max_deletions:
             standard = backups[0]
@@ -256,7 +256,7 @@ def check_time_span_parameters(args: argparse.Namespace) -> None:
         if time_span_str is None:
             continue
 
-        date_cutoff = dates.parse_time_span_to_timepoint(time_span_str, now)
+        date_cutoff = dates.past_timepoint(time_span_str, now)
         if last_date_cutoff and date_cutoff >= last_date_cutoff:
             raise CommandLineError(
                 f"The {period_word} time span ({time_span_str}) is not longer than "

--- a/lib/backup_deletion.py
+++ b/lib/backup_deletion.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import lib.backup_utilities as util
-from lib.datetime_calculations import parse_time_span_to_timepoint
+import lib.datetime_calculations as dates
 from lib.exceptions import CommandLineError
 import lib.filesystem as fs
 from lib.verification import verify_backup_checksum
@@ -93,7 +93,7 @@ def delete_backups_older_than(
     if not last_backup:
         return
     now = util.backup_datetime(last_backup)
-    timestamp_to_keep = parse_time_span_to_timepoint(time_span, now)
+    timestamp_to_keep = dates.parse_time_span_to_timepoint(time_span, now)
     first_deletion_message = (
         f"Deleting backups prior to {timestamp_to_keep.strftime('%Y-%m-%d %H:%M:%S')}.")
 
@@ -215,14 +215,16 @@ def delete_too_frequent_backups(
         if time_span_str is None:
             continue
 
-        date_cutoff = parse_time_span_to_timepoint(time_span_str, now)
+        date_cutoff = dates.parse_time_span_to_timepoint(time_span_str, now)
         backups = list(filter(old_enough(date_cutoff), util.all_backups(backup_folder)))
         while len(backups) > 1 and deletion_count < max_deletions:
             standard = backups[0]
             next_backup = backups[1]
-            next_timestamp = util.backup_datetime(next_backup)
-            earliest_standard_timestamp = parse_time_span_to_timepoint(period, next_timestamp)
-            if util.backup_datetime(standard).date() > earliest_standard_timestamp.date():
+            standard_timestamp = util.backup_datetime(standard)
+            earliest_next_backup = dates.parse_time_span_to_future_timepoint(
+                period,
+                standard_timestamp)
+            if util.backup_datetime(next_backup).date() < earliest_next_backup.date():
                 logger.info("Deleting non-%s backup: %s", period_word, next_backup)
                 deletion_count += 1
                 delete_single_backup(next_backup, verify_checksum_result_folder)
@@ -254,7 +256,7 @@ def check_time_span_parameters(args: argparse.Namespace) -> None:
         if time_span_str is None:
             continue
 
-        date_cutoff = parse_time_span_to_timepoint(time_span_str, now)
+        date_cutoff = dates.parse_time_span_to_timepoint(time_span_str, now)
         if last_date_cutoff and date_cutoff >= last_date_cutoff:
             raise CommandLineError(
                 f"The {period_word} time span ({time_span_str}) is not longer than "

--- a/lib/backup_deletion.py
+++ b/lib/backup_deletion.py
@@ -221,9 +221,7 @@ def delete_too_frequent_backups(
             standard = backups[0]
             next_backup = backups[1]
             standard_timestamp = util.backup_datetime(standard)
-            earliest_next_backup = dates.parse_time_span_to_future_timepoint(
-                period,
-                standard_timestamp)
+            earliest_next_backup = dates.future_timepoint(period, standard_timestamp)
             if util.backup_datetime(next_backup).date() < earliest_next_backup.date():
                 logger.info("Deleting non-%s backup: %s", period_word, next_backup)
                 deletion_count += 1

--- a/lib/backup_utilities.py
+++ b/lib/backup_utilities.py
@@ -6,7 +6,7 @@ import argparse
 from collections.abc import Callable
 
 from lib.filesystem import is_real_directory
-from lib.datetime_calculations import parse_time_span_to_timepoint
+from lib.datetime_calculations import past_timepoint
 
 
 backup_date_format = "%Y-%m-%d %H-%M-%S"
@@ -97,5 +97,5 @@ def should_do_periodic_action(
     if not previous_action_date:
         return True
 
-    required_action_date = parse_time_span_to_timepoint(time_span, now)
+    required_action_date = past_timepoint(time_span, now)
     return previous_action_date <= required_action_date

--- a/lib/datetime_calculations.py
+++ b/lib/datetime_calculations.py
@@ -83,9 +83,7 @@ def months_ago(now: datetime.datetime | datetime.date, month_count: int) -> date
     return fix_end_of_month(new_year, new_month, now.day)
 
 
-def parse_time_span_to_future_timepoint(
-        time_span: str,
-        now: datetime.datetime | None = None) -> datetime.datetime:
+def future_timepoint(time_span: str, now: datetime.datetime | None = None) -> datetime.datetime:
     """
     Parse a string representing a time span into a datetime representing a date that far ahead.
 

--- a/lib/datetime_calculations.py
+++ b/lib/datetime_calculations.py
@@ -76,10 +76,11 @@ def months_ago(now: datetime.datetime | datetime.date, month_count: int) -> date
     >>> months_ago(date, 3)
     datetime.date(2026, 2, 28)
     """
-    new_month = now.month - (month_count % 12)
-    new_year = now.year - (month_count // 12)
+    months_in_year = 12
+    new_month = now.month - (month_count % months_in_year)
+    new_year = now.year - (month_count // months_in_year)
     if new_month < 1:
-        new_month += 12
+        new_month += months_in_year
         new_year -= 1
     return fix_end_of_month(new_year, new_month, now.day)
 

--- a/lib/datetime_calculations.py
+++ b/lib/datetime_calculations.py
@@ -5,9 +5,7 @@ import datetime
 from lib.exceptions import CommandLineError
 
 
-def parse_time_span_to_timepoint(
-        time_span: str,
-        now: datetime.datetime | None = None) -> datetime.datetime:
+def past_timepoint(time_span: str, now: datetime.datetime | None = None) -> datetime.datetime:
     """
     Parse a string representing a time span into a datetime representing a date that long ago.
 

--- a/lib/datetime_calculations.py
+++ b/lib/datetime_calculations.py
@@ -84,6 +84,86 @@ def months_ago(now: datetime.datetime | datetime.date, month_count: int) -> date
     return fix_end_of_month(new_year, new_month, now.day)
 
 
+def parse_time_span_to_future_timepoint(
+        time_span: str,
+        now: datetime.datetime | None = None) -> datetime.datetime:
+    """
+    Parse a string representing a time span into a datetime representing a date that far ahead.
+
+    For example, if time_span is "6m", the result is a date six calendar months ahead.
+
+    Arguments:
+        time_span: A string consisting of a positive integer followed by a single letter: "d"
+            for days, "w" for weeks, "m" for calendar months, and "y" for calendar years.
+        now: The point from which to calculate the past point. If None, use
+            datetime.datetime.now().
+
+    Returns:
+        datetime: A datetime in the future.
+
+    Raises:
+        CommandLineError: If time_span cannot be parsed.
+    """
+    time_span = "".join(time_span.lower().split())
+    try:
+        number = int(time_span[:-1])
+    except ValueError:
+        raise CommandLineError(
+            f"Invalid number in time span (must be a whole number): {time_span}") from None
+
+    if number < 1:
+        raise CommandLineError(f"Invalid number in time span (must be positive): {time_span}")
+
+    letter = time_span[-1]
+    now = now or datetime.datetime.now()
+    match letter:
+        case "d":
+            return now + datetime.timedelta(days=number)
+        case "w":
+            return now + datetime.timedelta(weeks=number)
+        case "m":
+            new_date = months_ahead(now, number)
+            return datetime.datetime.combine(new_date, now.time())
+        case "y":
+            new_date = fix_end_of_month(now.year + number, now.month, now.day)
+            return datetime.datetime.combine(new_date, now.time())
+        case _:
+            raise CommandLineError(f"Invalid time (valid units: {list("dwmy")}): {time_span}")
+
+
+def months_ahead(now: datetime.datetime | datetime.date, month_count: int) -> datetime.date:
+    """
+    Return a date that is a number of calendar months ahead.
+
+    The day of the month is not changed unless necessary to produce a valid date
+    (see fix_end_of_month()).
+
+    Arguments:
+        now: The date or datetime from which to calculate.
+        month_count: How many months to go forward.
+
+    Returns:
+        date: A valid date that is the same day of the month a given number of months forward.
+
+    >>> date = datetime.date(2026, 1, 31)
+    >>> months_ahead(date, 1)
+    datetime.date(2026, 2, 28)
+
+    >>> months_ahead(date, 2)
+    datetime.date(2026, 3, 31)
+
+    >>> months_ahead(date, 3)
+    datetime.date(2026, 4, 30)
+    """
+    months_in_year = 12
+    new_month = now.month + (month_count % months_in_year)
+    new_year = now.year + (month_count // months_in_year)
+    if new_month > months_in_year:
+        new_month -= months_in_year
+        new_year += 1
+    return fix_end_of_month(new_year, new_month, now.day)
+
+
 def fix_end_of_month(year: int, month: int, day: int) -> datetime.date:
     """
     Replace a day past the end of the month (e.g., Feb. 31) with the last day of the same month.

--- a/lib/move_backups.py
+++ b/lib/move_backups.py
@@ -12,7 +12,7 @@ import lib.backup_info as info
 from lib.backup_lock import Backup_Lock
 from lib.backup_utilities import all_backups, backup_datetime
 from lib.console import plural_noun, print_run_title
-from lib.datetime_calculations import parse_time_span_to_timepoint
+from lib.datetime_calculations import past_timepoint
 from lib.exceptions import CommandLineError
 from lib.filesystem import absolute_path, get_existing_path
 
@@ -132,7 +132,7 @@ def choose_backups_to_move(args: argparse.Namespace, old_backup_location: Path) 
     if args.move_count:
         backups_to_move = last_n_backups(args.move_count, old_backup_location)
     elif args.move_age:
-        oldest_backup_date = parse_time_span_to_timepoint(args.move_age)
+        oldest_backup_date = past_timepoint(args.move_age)
         backups_to_move = backups_since(oldest_backup_date, old_backup_location)
     elif args.move_since:
         oldest_backup_date = datetime.datetime.strptime(args.move_since, "%Y-%m-%d")

--- a/testing/test.py
+++ b/testing/test.py
@@ -2550,7 +2550,7 @@ class MoveBackupsTests(TestCaseWithTemporaryFilesAndFolders):
     def test_move_age_backups_moves_only_backups_within_given_timespan(self) -> None:
         """Test that moving backups based on a time span works."""
         create_old_monthly_backups(self.backup_path, 25)
-        six_months_ago = dates.parse_time_span_to_timepoint("6m")
+        six_months_ago = dates.past_timepoint("6m")
         backups_to_move = moving.backups_since(six_months_ago, self.backup_path)
         self.assertEqual(len(backups_to_move), 6)
         self.assertEqual(moving.last_n_backups(6, self.backup_path), backups_to_move)
@@ -4855,78 +4855,78 @@ class ParseTimeSpanTests(unittest.TestCase):
     def test_parse_timespan_with_no_numeric_part_is_an_error(self) -> None:
         """Test that the lack of a number in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_timepoint("y")
+            dates.past_timepoint("y")
 
     def test_parse_timespan_with_no_time_unit_part_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_timepoint("100")
+            dates.past_timepoint("100")
 
     def test_parse_timespan_with_small_or_negative_number_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_timepoint("0.5d")
+            dates.past_timepoint("0.5d")
 
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_timepoint("-2y")
+            dates.past_timepoint("-2y")
 
     def test_parse_timespan_with_invalid_time_unit_is_an_error(self) -> None:
         """Test that an unknown time unit raise an exception."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_timepoint("3u")
+            dates.past_timepoint("3u")
 
     def test_parse_timespan_correctly_calculates_days_ago(self) -> None:
         """Test that arguments of the form "Nd" for some number N gives the correct results."""
         for days in range(1, 10):
             now = datetime.datetime.now()
-            then = dates.parse_time_span_to_timepoint(f"{days}d", now)
+            then = dates.past_timepoint(f"{days}d", now)
             self.assertEqual(now - then, datetime.timedelta(days=days))
 
     def test_parse_timespan_correctly_calculates_weeks_ago(self) -> None:
         """Test that arguments of the form "Nw" for some number N gives the correct results."""
         for weeks in range(1, 10):
             now = datetime.datetime.now()
-            then = dates.parse_time_span_to_timepoint(f"{weeks}w", now)
+            then = dates.past_timepoint(f"{weeks}w", now)
             self.assertEqual(now - then, datetime.timedelta(weeks=weeks))
 
     def test_parse_timespan_correctly_calculates_months_ago(self) -> None:
         """Test that arguments of the form "Nm" for some number N gives the correct results."""
         now = datetime.datetime(2024, 3, 31, 12, 0, 0)
         expected_then_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
-        then_1 = dates.parse_time_span_to_timepoint("1m", now)
+        then_1 = dates.past_timepoint("1m", now)
         self.assertEqual(then_1, expected_then_1)
 
         expected_then_2 = datetime.datetime(2024, 1, 31, 12, 0, 0)
-        then_2 = dates.parse_time_span_to_timepoint("2m", now)
+        then_2 = dates.past_timepoint("2m", now)
         self.assertEqual(then_2, expected_then_2)
 
     def test_parse_timespan_correctly_calculates_years_ago(self) -> None:
         """Test that arguments of the form "Ny" for some number N gives the correct results."""
         now_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
         expected_then_1 = datetime.datetime(2023, 2, 28, 12, 0, 0)
-        then_1 = dates.parse_time_span_to_timepoint("1y", now_1)
+        then_1 = dates.past_timepoint("1y", now_1)
         self.assertEqual(then_1, expected_then_1)
 
         now_2 = datetime.datetime(2025, 1, 31, 12, 0, 0)
         expected_then_2 = datetime.datetime(2023, 1, 31, 12, 0, 0)
-        then_2 = dates.parse_time_span_to_timepoint("2y", now_2)
+        then_2 = dates.past_timepoint("2y", now_2)
         self.assertEqual(then_2, expected_then_2)
 
     def test_parse_timespan_is_case_insensitive(self) -> None:
         """Test that upper and lowercase units are both valid in parse_time_span_to_time_point."""
         now = datetime.datetime.now()
         for unit in "dwmy":
-            lower_result = dates.parse_time_span_to_timepoint(f"1{unit}", now)
-            upper_result = dates.parse_time_span_to_timepoint(f"1{unit.upper()}", now)
+            lower_result = dates.past_timepoint(f"1{unit}", now)
+            upper_result = dates.past_timepoint(f"1{unit.upper()}", now)
             self.assertEqual(lower_result, upper_result)
 
     def test_parse_timespan_is_space_insensitive(self) -> None:
         """Test that whitespace does not affect results in parse_time_span_to_time_point."""
         now = datetime.datetime.now()
         for unit in "dwmy":
-            result = dates.parse_time_span_to_timepoint(f"1{unit}", now)
-            space_result = dates.parse_time_span_to_timepoint(f"1 {unit}", now)
-            tab_result = dates.parse_time_span_to_timepoint(f"1\t{unit}", now)
+            result = dates.past_timepoint(f"1{unit}", now)
+            space_result = dates.past_timepoint(f"1 {unit}", now)
+            tab_result = dates.past_timepoint(f"1\t{unit}", now)
             self.assertEqual(result, space_result)
             self.assertEqual(result, tab_result)
 

--- a/testing/test.py
+++ b/testing/test.py
@@ -4933,78 +4933,78 @@ class ParseTimeSpanTests(unittest.TestCase):
     def test_parse_future_timespan_with_no_numeric_part_is_an_error(self) -> None:
         """Test that the lack of a number in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_future_timepoint("y")
+            dates.future_timepoint("y")
 
     def test_parse_future_timespan_with_no_time_unit_part_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_future_timepoint("100")
+            dates.future_timepoint("100")
 
     def test_parse_future_timespan_with_small_or_negative_number_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_future_timepoint("0.5d")
+            dates.future_timepoint("0.5d")
 
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_future_timepoint("-2y")
+            dates.future_timepoint("-2y")
 
     def test_parse_future_timespan_with_invalid_time_unit_is_an_error(self) -> None:
         """Test that an unknown time unit raise an exception."""
         with self.assertRaises(CommandLineError):
-            dates.parse_time_span_to_future_timepoint("3u")
+            dates.future_timepoint("3u")
 
     def test_parse_future_timespan_correctly_calculates_days_ago(self) -> None:
         """Test that arguments of the form "Nd" for some number N gives the correct results."""
         for days in range(1, 10):
             now = datetime.datetime.now()
-            soon = dates.parse_time_span_to_future_timepoint(f"{days}d", now)
+            soon = dates.future_timepoint(f"{days}d", now)
             self.assertEqual(soon - now, datetime.timedelta(days=days))
 
     def test_parse_future_timespan_correctly_calculates_weeks_ago(self) -> None:
         """Test that arguments of the form "Nw" for some number N gives the correct results."""
         for weeks in range(1, 10):
             now = datetime.datetime.now()
-            soon = dates.parse_time_span_to_future_timepoint(f"{weeks}w", now)
+            soon = dates.future_timepoint(f"{weeks}w", now)
             self.assertEqual(soon - now, datetime.timedelta(weeks=weeks))
 
     def test_parse_future_timespan_correctly_calculates_months_ago(self) -> None:
         """Test that arguments of the form "Nm" for some number N gives the correct results."""
         now = datetime.datetime(2024, 1, 31, 12, 0, 0)
         expected_soon_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
-        soon_1 = dates.parse_time_span_to_future_timepoint("1m", now)
+        soon_1 = dates.future_timepoint("1m", now)
         self.assertEqual(soon_1, expected_soon_1)
 
         expected_soon_2 = datetime.datetime(2024, 3, 31, 12, 0, 0)
-        soon_2 = dates.parse_time_span_to_future_timepoint("2m", now)
+        soon_2 = dates.future_timepoint("2m", now)
         self.assertEqual(soon_2, expected_soon_2)
 
     def test_parse_future_timespan_correctly_calculates_years_ago(self) -> None:
         """Test that arguments of the form "Ny" for some number N gives the correct results."""
         now_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
         expected_soon_1 = datetime.datetime(2025, 2, 28, 12, 0, 0)
-        soon_1 = dates.parse_time_span_to_future_timepoint("1y", now_1)
+        soon_1 = dates.future_timepoint("1y", now_1)
         self.assertEqual(soon_1, expected_soon_1)
 
         now_2 = datetime.datetime(2025, 1, 31, 12, 0, 0)
         expected_soon_2 = datetime.datetime(2027, 1, 31, 12, 0, 0)
-        soon_2 = dates.parse_time_span_to_future_timepoint("2y", now_2)
+        soon_2 = dates.future_timepoint("2y", now_2)
         self.assertEqual(soon_2, expected_soon_2)
 
     def test_parse_future_timespan_is_case_insensitive(self) -> None:
         """Test that upper/lowercase units are both valid in parse_time_span_to_future_timepoint."""
         now = datetime.datetime.now()
         for unit in "dwmy":
-            lower_result = dates.parse_time_span_to_future_timepoint(f"1{unit}", now)
-            upper_result = dates.parse_time_span_to_future_timepoint(f"1{unit.upper()}", now)
+            lower_result = dates.future_timepoint(f"1{unit}", now)
+            upper_result = dates.future_timepoint(f"1{unit.upper()}", now)
             self.assertEqual(lower_result, upper_result)
 
     def test_parse_future_timespan_is_space_insensitive(self) -> None:
         """Test that whitespace does not affect results in parse_time_span_to_future_time_point."""
         now = datetime.datetime.now()
         for unit in "dwmy":
-            result = dates.parse_time_span_to_future_timepoint(f"1{unit}", now)
-            space_result = dates.parse_time_span_to_future_timepoint(f"1 {unit}", now)
-            tab_result = dates.parse_time_span_to_future_timepoint(f"1\t{unit}", now)
+            result = dates.future_timepoint(f"1{unit}", now)
+            space_result = dates.future_timepoint(f"1 {unit}", now)
+            tab_result = dates.future_timepoint(f"1\t{unit}", now)
             self.assertEqual(result, space_result)
             self.assertEqual(result, tab_result)
 

--- a/testing/test.py
+++ b/testing/test.py
@@ -6003,13 +6003,13 @@ class MonthsAheadTests(unittest.TestCase):
 
     def test_end_of_month_date_results_in_end_of_month_date(self) -> None:
         """An end-of-month date result in an end-of-month date if the result is a shorter month."""
-        date = datetime.date(2023, 3, 31)
+        date = datetime.date(2023, 1, 31)
         calculated_date = dates.months_ahead(date, 1)
-        expected_date = datetime.date(2023, 4, 30)
+        expected_date = datetime.date(2023, 2, 28)
         self.assertEqual(expected_date, calculated_date)
 
-        date = datetime.date(2024, 3, 31)
-        calculated_date = dates.months_ago(date, 1)
+        date = datetime.date(2024, 1, 31)
+        calculated_date = dates.months_ahead(date, 1)
         expected_date = datetime.date(2024, 2, 29)
         self.assertEqual(expected_date, calculated_date)
 

--- a/testing/test.py
+++ b/testing/test.py
@@ -2252,12 +2252,7 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
                 time_span_to_keep_all_backups = "1d"
                 backups = util.all_backups(self.backup_path)
                 first_backup_date = util.backup_datetime(backups[0]).date()
-                retained_date = first_backup_date
-                while dates.months_ago(retained_date, 1) < first_backup_date:
-                    retained_date += datetime.timedelta(days=1)
-
-                shortest_month = datetime.timedelta(days=28)
-                self.assertGreaterEqual(retained_date - first_backup_date, shortest_month)
+                retained_date = dates.months_ahead(first_backup_date, 1)
                 timestamp = util.backup_datetime
                 kept_backup, = (b for b in backups if timestamp(b).date() == retained_date)
                 expected_backups_remaining = [backups[0], kept_backup, backups[-2], backups[-1]]
@@ -4935,6 +4930,84 @@ class ParseTimeSpanTests(unittest.TestCase):
             self.assertEqual(result, space_result)
             self.assertEqual(result, tab_result)
 
+    def test_parse_future_timespan_with_no_numeric_part_is_an_error(self) -> None:
+        """Test that the lack of a number in the argument is an error."""
+        with self.assertRaises(CommandLineError):
+            dates.parse_time_span_to_future_timepoint("y")
+
+    def test_parse_future_timespan_with_no_time_unit_part_is_an_error(self) -> None:
+        """Test that the lack of a unit in the argument is an error."""
+        with self.assertRaises(CommandLineError):
+            dates.parse_time_span_to_future_timepoint("100")
+
+    def test_parse_future_timespan_with_small_or_negative_number_is_an_error(self) -> None:
+        """Test that the lack of a unit in the argument is an error."""
+        with self.assertRaises(CommandLineError):
+            dates.parse_time_span_to_future_timepoint("0.5d")
+
+        with self.assertRaises(CommandLineError):
+            dates.parse_time_span_to_future_timepoint("-2y")
+
+    def test_parse_future_timespan_with_invalid_time_unit_is_an_error(self) -> None:
+        """Test that an unknown time unit raise an exception."""
+        with self.assertRaises(CommandLineError):
+            dates.parse_time_span_to_future_timepoint("3u")
+
+    def test_parse_future_timespan_correctly_calculates_days_ago(self) -> None:
+        """Test that arguments of the form "Nd" for some number N gives the correct results."""
+        for days in range(1, 10):
+            now = datetime.datetime.now()
+            soon = dates.parse_time_span_to_future_timepoint(f"{days}d", now)
+            self.assertEqual(soon - now, datetime.timedelta(days=days))
+
+    def test_parse_future_timespan_correctly_calculates_weeks_ago(self) -> None:
+        """Test that arguments of the form "Nw" for some number N gives the correct results."""
+        for weeks in range(1, 10):
+            now = datetime.datetime.now()
+            soon = dates.parse_time_span_to_future_timepoint(f"{weeks}w", now)
+            self.assertEqual(soon - now, datetime.timedelta(weeks=weeks))
+
+    def test_parse_future_timespan_correctly_calculates_months_ago(self) -> None:
+        """Test that arguments of the form "Nm" for some number N gives the correct results."""
+        now = datetime.datetime(2024, 1, 31, 12, 0, 0)
+        expected_soon_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
+        soon_1 = dates.parse_time_span_to_future_timepoint("1m", now)
+        self.assertEqual(soon_1, expected_soon_1)
+
+        expected_soon_2 = datetime.datetime(2024, 3, 31, 12, 0, 0)
+        soon_2 = dates.parse_time_span_to_future_timepoint("2m", now)
+        self.assertEqual(soon_2, expected_soon_2)
+
+    def test_parse_future_timespan_correctly_calculates_years_ago(self) -> None:
+        """Test that arguments of the form "Ny" for some number N gives the correct results."""
+        now_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
+        expected_soon_1 = datetime.datetime(2025, 2, 28, 12, 0, 0)
+        soon_1 = dates.parse_time_span_to_future_timepoint("1y", now_1)
+        self.assertEqual(soon_1, expected_soon_1)
+
+        now_2 = datetime.datetime(2025, 1, 31, 12, 0, 0)
+        expected_soon_2 = datetime.datetime(2027, 1, 31, 12, 0, 0)
+        soon_2 = dates.parse_time_span_to_future_timepoint("2y", now_2)
+        self.assertEqual(soon_2, expected_soon_2)
+
+    def test_parse_future_timespan_is_case_insensitive(self) -> None:
+        """Test that upper/lowercase units are both valid in parse_time_span_to_future_timepoint."""
+        now = datetime.datetime.now()
+        for unit in "dwmy":
+            lower_result = dates.parse_time_span_to_future_timepoint(f"1{unit}", now)
+            upper_result = dates.parse_time_span_to_future_timepoint(f"1{unit.upper()}", now)
+            self.assertEqual(lower_result, upper_result)
+
+    def test_parse_future_timespan_is_space_insensitive(self) -> None:
+        """Test that whitespace does not affect results in parse_time_span_to_future_time_point."""
+        now = datetime.datetime.now()
+        for unit in "dwmy":
+            result = dates.parse_time_span_to_future_timepoint(f"1{unit}", now)
+            space_result = dates.parse_time_span_to_future_timepoint(f"1 {unit}", now)
+            tab_result = dates.parse_time_span_to_future_timepoint(f"1\t{unit}", now)
+            self.assertEqual(result, space_result)
+            self.assertEqual(result, tab_result)
+
 
 class RemoveQuotesTests(unittest.TestCase):
     """Tests for remove_quotes() function."""
@@ -5853,6 +5926,38 @@ class MonthsAgoTests(unittest.TestCase):
         date = datetime.date(2021, 5, 31)
         calculated_date = dates.months_ago(date, 7)
         expected_date = datetime.date(2020, 10, 31)
+        self.assertEqual(expected_date, calculated_date)
+
+
+class MonthsAheadTests(unittest.TestCase):
+    """Check calculations of calendar months ahead."""
+
+    def test_middle_of_month_dates_in_same_year_result_in_only_month_changing(self) -> None:
+        """Dates in the middle of the month only change month within the same eyar."""
+        date = datetime.date(2025, 1, 13)
+        for ahead_month in range(12):
+            calculated_date = dates.months_ahead(date, ahead_month)
+            new_month = date.month + ahead_month
+            expected_date = datetime.date(date.year, new_month, date.day)
+            self.assertEqual(expected_date, calculated_date)
+
+    def test_end_of_month_date_results_in_end_of_month_date(self) -> None:
+        """An end-of-month date result in an end-of-month date if the result is a shorter month."""
+        date = datetime.date(2023, 3, 31)
+        calculated_date = dates.months_ahead(date, 1)
+        expected_date = datetime.date(2023, 4, 30)
+        self.assertEqual(expected_date, calculated_date)
+
+        date = datetime.date(2024, 3, 31)
+        calculated_date = dates.months_ago(date, 1)
+        expected_date = datetime.date(2024, 2, 29)
+        self.assertEqual(expected_date, calculated_date)
+
+    def test_months_ahead_correctly_handles_crossing_year_boundries(self) -> None:
+        """Ensure calculated date is correct when result is in previous year."""
+        date = datetime.date(2021, 5, 31)
+        calculated_date = dates.months_ahead(date, 9)
+        expected_date = datetime.date(2022, 2, 28)
         self.assertEqual(expected_date, calculated_date)
 
 

--- a/testing/test.py
+++ b/testing/test.py
@@ -4912,17 +4912,17 @@ class ClassifyPathsTests(unittest.TestCase):
 class ParseTimeSpanTests(unittest.TestCase):
     """Tests for parse_time_span_to_time_point() function."""
 
-    def test_parse_timespan_with_no_numeric_part_is_an_error(self) -> None:
+    def test_parse_past_timespan_with_no_numeric_part_is_an_error(self) -> None:
         """Test that the lack of a number in the argument is an error."""
         with self.assertRaises(CommandLineError):
             dates.past_timepoint("y")
 
-    def test_parse_timespan_with_no_time_unit_part_is_an_error(self) -> None:
+    def test_parse_past_timespan_with_no_time_unit_part_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
             dates.past_timepoint("100")
 
-    def test_parse_timespan_with_small_or_negative_number_is_an_error(self) -> None:
+    def test_parse_past_timespan_with_small_or_negative_number_is_an_error(self) -> None:
         """Test that the lack of a unit in the argument is an error."""
         with self.assertRaises(CommandLineError):
             dates.past_timepoint("0.5d")
@@ -4930,26 +4930,26 @@ class ParseTimeSpanTests(unittest.TestCase):
         with self.assertRaises(CommandLineError):
             dates.past_timepoint("-2y")
 
-    def test_parse_timespan_with_invalid_time_unit_is_an_error(self) -> None:
+    def test_parse_past_timespan_with_invalid_time_unit_is_an_error(self) -> None:
         """Test that an unknown time unit raise an exception."""
         with self.assertRaises(CommandLineError):
             dates.past_timepoint("3u")
 
-    def test_parse_timespan_correctly_calculates_days_ago(self) -> None:
+    def test_parse_past_timespan_correctly_calculates_days_ago(self) -> None:
         """Test that arguments of the form "Nd" for some number N gives the correct results."""
         for days in range(1, 10):
             now = datetime.datetime.now()
             then = dates.past_timepoint(f"{days}d", now)
             self.assertEqual(now - then, datetime.timedelta(days=days))
 
-    def test_parse_timespan_correctly_calculates_weeks_ago(self) -> None:
+    def test_parse_past_timespan_correctly_calculates_weeks_ago(self) -> None:
         """Test that arguments of the form "Nw" for some number N gives the correct results."""
         for weeks in range(1, 10):
             now = datetime.datetime.now()
             then = dates.past_timepoint(f"{weeks}w", now)
             self.assertEqual(now - then, datetime.timedelta(weeks=weeks))
 
-    def test_parse_timespan_correctly_calculates_months_ago(self) -> None:
+    def test_parse_past_timespan_correctly_calculates_months_ago(self) -> None:
         """Test that arguments of the form "Nm" for some number N gives the correct results."""
         now = datetime.datetime(2024, 3, 31, 12, 0, 0)
         expected_then_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
@@ -4960,7 +4960,7 @@ class ParseTimeSpanTests(unittest.TestCase):
         then_2 = dates.past_timepoint("2m", now)
         self.assertEqual(then_2, expected_then_2)
 
-    def test_parse_timespan_correctly_calculates_years_ago(self) -> None:
+    def test_parse_past_timespan_correctly_calculates_years_ago(self) -> None:
         """Test that arguments of the form "Ny" for some number N gives the correct results."""
         now_1 = datetime.datetime(2024, 2, 29, 12, 0, 0)
         expected_then_1 = datetime.datetime(2023, 2, 28, 12, 0, 0)
@@ -4972,7 +4972,7 @@ class ParseTimeSpanTests(unittest.TestCase):
         then_2 = dates.past_timepoint("2y", now_2)
         self.assertEqual(then_2, expected_then_2)
 
-    def test_parse_timespan_is_case_insensitive(self) -> None:
+    def test_parse_past_timespan_is_case_insensitive(self) -> None:
         """Test that upper and lowercase units are both valid in parse_time_span_to_time_point."""
         now = datetime.datetime.now()
         for unit in "dwmy":
@@ -4980,7 +4980,7 @@ class ParseTimeSpanTests(unittest.TestCase):
             upper_result = dates.past_timepoint(f"1{unit.upper()}", now)
             self.assertEqual(lower_result, upper_result)
 
-    def test_parse_timespan_is_space_insensitive(self) -> None:
+    def test_parse_past_timespan_is_space_insensitive(self) -> None:
         """Test that whitespace does not affect results in parse_time_span_to_time_point."""
         now = datetime.datetime.now()
         for unit in "dwmy":

--- a/wiki/delete.md
+++ b/wiki/delete.md
@@ -68,14 +68,20 @@ If they are used together, the time span for `--keep-weekly-after` must be the s
 #### A note about `--keep-monthly-after`
 
 Because months are not all the same length, the effects of `--keep-monthly-after` can be unexpected.
+If the oldest backup has a date near then end of the month, then the monthly retained backups afterwards may have different dates depending on the lengths of months afterwards.
 
 For example, let's say you are creating daily backups and use the `--keep-monthly-after` option.
-If the oldest backup in a set is dated March 31, the next backup to be kept will be dated May 1.
-When Vintage Backup is calculating which backups to keep, it checks for the next backup with a date that is a month after March 31 while deleting all other backups in between.
-When it reaches April 30, it calculates that a month prior is March 30, which is before the oldest backup, and so deletes the April 30 backup.
-When it reaches May 1, it calculates that a month prior is April 1, which is after the oldest backup, and so keeps it.
+If the oldest backup in a set is dated October 31, 2026, the subsequent retained backups will be:
 
-So, the time between backups retained by `--keep-monthly-after` will be *at least* a calendar month apart, give or take a few days.
+- 2026-10-31
+- 2026-11-30
+- 2026-12-30
+- 2027-01-30
+- 2027-02-28
+- 2027-03-28
+
+All retained backups will be on the 28th day from then on.
+The date of a retained backup changes when a shorter month is encountered.
 
 
 ## Other options


### PR DESCRIPTION
Create a months_ahead() function to keep the dates of backups retained by --keep-monthly-after near the same date within months.

Fixes #253