### PR TITLE
Make DiskUsageMock more reliable

### DIFF
--- a/testing/test.py
+++ b/testing/test.py
@@ -1930,8 +1930,8 @@ class DiskUsageMock:
         The total storage space of the mock disk will be the used space of the path plus the initial
         free space
         """
-        self.original_disk_usage = copy.copy(shutil.disk_usage)
-        initial_used = self.original_disk_usage(path).used
+        self.base_path = fs.absolute_path(path)
+        initial_used = self.used_space(self.base_path)
         self.total = initial_used + initial_free_space
 
     def __call__(self, path: Path | str) -> Mock_Usage_Result:
@@ -1944,8 +1944,38 @@ class DiskUsageMock:
         Returns:
             storage_stats: Storage amounts (total, used, free).
         """
-        used = self.original_disk_usage(path).used
+        used = self.used_space(path)
         return self.Mock_Usage_Result(self.total, used, self.total - used)
+
+    def used_space(self, path: Path | str) -> int:
+        """
+        Calculate space used within the base folder.
+
+        Arguments:
+            path: The path to query the used space within the directory.
+
+        Returns:
+            int: The number of bytes used within top-level folder used in the __init__() method of
+                this class.
+
+        Raises:
+            ValueError: If the path argument is not a subpath of the __init__() path argument.
+        """
+        path = fs.absolute_path(path)
+        if not path.is_relative_to(self.base_path):
+            raise ValueError(f"{path} is not a subdirectory of {self.base_path}")
+
+        total_used = 0
+        for directory, _, file_names in self.base_path.walk():
+            for file_name in file_names:
+                file_path = directory/file_name
+                total_used += file_path.stat(follow_symlinks=False).st_size
+
+        return total_used
+
+    def total_size(self) -> int:
+        """Returns the total size of this mock drive."""
+        return self.total
 
 
 class MockCopy2:
@@ -2043,6 +2073,7 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
                         "--free-up", goal_space_str],
                         self)
                 self.assertEqual(exit_code, 0, method)
+                backups_after_deletion += 1  # to include the new backup
             else:
                 raise NotImplementedError(f"Delete backup test not implemented for {method}")
             backups_left = len(util.all_backups(self.backup_path))
@@ -2436,11 +2467,11 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
     def test_error_raised_when_no_backups_to_delete_and_no_space(self) -> None:
         """If space runs out during a backup and there are no backups to delete, raise error."""
         create_user_data(self.user_path)
-        mock_storage = DiskUsageMock(self.backup_path, 10_000)
+        mock_storage = DiskUsageMock(self.backup_path, 100)
         args = argparse.parse_command_line([
             "-u", str(self.user_path),
             "-b", str(self.backup_path),
-            "--free-up", "1000000"])
+            "--free-up", str(mock_storage.total_size())])
         with (patch("lib.backup.shutil.disk_usage", mock_storage),
               patch("lib.backup.shutil.copy2", MockCopy2()),
               self.assertRaises(CommandLineError) as error):
@@ -2452,12 +2483,12 @@ class DeleteBackupTests(TestCaseWithTemporaryFilesAndFolders):
     def test_error_raised_when_one_backup_left_and_no_space(self) -> None:
         """If space runs out during a backup and there is only one backup, raise error."""
         create_user_data(self.user_path)
+        mock_storage = DiskUsageMock(self.backup_path, 100)
         create_old_monthly_backups(self.backup_path, 1)
-        mock_storage = DiskUsageMock(self.backup_path, 10_000)
         args = argparse.parse_command_line([
             "-u", str(self.user_path),
             "-b", str(self.backup_path),
-            "--free-up", "1000000"])
+            "--free-up", str(mock_storage.total_size())])
         with (patch("lib.backup.shutil.disk_usage", mock_storage),
               patch("lib.backup.shutil.copy2", MockCopy2()),
               self.assertRaises(CommandLineError) as error):

--- a/testing/test.py
+++ b/testing/test.py
@@ -1924,7 +1924,8 @@ class DiskUsageMock:
         Create a mock hard drive with the given amount of free space.
 
         Arguments:
-            path: A path in the test storage media from which the initial used space will be read
+            path: A path in the test storage media from which the initial used space will be read.
+                This path will act as the base path of the mock disk.
             initial_free_space: An initial amount of free space in bytes for the test storage
 
         The total storage space of the mock disk will be the used space of the path plus the initial
@@ -1939,7 +1940,7 @@ class DiskUsageMock:
         Create a result as from shutil.disk_usage().
 
         Arguments:
-            path: The existing path for which the storage media that contains it will be queried.
+            path: The existing path for which the disk that contains it will be queried.
 
         Returns:
             storage_stats: Storage amounts (total, used, free).
@@ -1952,7 +1953,7 @@ class DiskUsageMock:
         Calculate space used within the base folder.
 
         Arguments:
-            path: The path to query the used space within the directory.
+            path: A path within the disk to query the used space within the directory.
 
         Returns:
             int: The number of bytes used within top-level folder used in the __init__() method of


### PR DESCRIPTION
Remove use of shutil.disk_usage(). Now, a single folder acts like a disk with a set size. The usage is measured by directly counting the bytes in all files.

Now, there should be no random failures during --free-up tests.